### PR TITLE
Add a shell.nix to setup dev enviroment and compile on nixos

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,7 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> {}, recompile ? false }:
 
 pkgs.mkShell {
   buildInputs = [
-    pkgs.lua5_1
     pkgs.luarocks
     pkgs.luajit
     pkgs.cairo
@@ -18,49 +17,61 @@ pkgs.mkShell {
     pkgs.libxkbcommon
 
     pkgs.luajitPackages.lgi
-    pkgs.lua51Packages.lgi
     pkgs.gobject-introspection
   ];
 
   shellHook = ''
-    # Set environment variables for the libraries
-    export CAIRO_DIR=${pkgs.cairo}
-    export EV_DIR=${pkgs.libev}
-    export LUAJIT_5_1_DIR=${pkgs.luajit}
-    export X11_DIR=${pkgs.xorg.libX11}
-    export XCB_DIR=${pkgs.xorg.libxcb}
+    # Have to do this jank to avoid escaping every quote in the build 
+    ${if recompile then "export RECOMPILE=1" else "export RECOMPILE=0" } 
+    
+    if ! luarocks list --local --lua-version=5.1 | grep -q "terra"; then
+      echo "Terra not installed, compiling"
+      export RECOMPILE=1
+    fi
 
-    # Some jank to extract the header directory to pass to the includes
-    export XCB_UTIL_DIR=${pkgs.xorg.xcbutil}
-    export XCB_UTIL_DRV_DIR=$(nix-store --query --deriver $XCB_UTIL_DIR)
-    export XCB_HEADER_DIR=$(nix-store --query --outputs $XCB_UTIL_DRV_DIR | grep "dev")
+    if [ "$RECOMPILE" = 1 ]; then
+      # Set environment variables for the libraries
+      export CAIRO_DIR=${pkgs.cairo}
+      export EV_DIR=${pkgs.libev}
+      export LUAJIT_5_1_DIR=${pkgs.luajit}
+      export X11_DIR=${pkgs.xorg.libX11}
+      export XCB_DIR=${pkgs.xorg.libxcb}
 
-    export XCB_CURSOR_DIR=${pkgs.xcb-util-cursor}
-    export XCB_ERRORS_DIR=${pkgs.xorg.xcbutilerrors}
-    export XCB_KEYSYMS_DIR=${pkgs.xorg.xcbutilkeysyms}
-    export XKBCOMMON_DIR=${pkgs.libxkbcommon}
-    export XKBCOMMON_X11_DIR=${pkgs.libxkbcommon}
+      # Some jank to extract the header directory to pass to the includes
+      export XCB_UTIL_DIR=${pkgs.xorg.xcbutil}
+      export XCB_UTIL_DRV_DIR=$(nix-store --query --deriver $XCB_UTIL_DIR)
+      export XCB_HEADER_DIR=$(nix-store --query --outputs $XCB_UTIL_DRV_DIR | grep "dev")
 
-    # Add LuaJIT include directory
-    export LUA_INCDIR=${pkgs.luajit}/include/luajit-2.1
+      export XCB_CURSOR_DIR=${pkgs.xcb-util-cursor}
+      export XCB_ERRORS_DIR=${pkgs.xorg.xcbutilerrors}
+      export XCB_KEYSYMS_DIR=${pkgs.xorg.xcbutilkeysyms}
+      export XKBCOMMON_DIR=${pkgs.libxkbcommon}
+      export XKBCOMMON_X11_DIR=${pkgs.libxkbcommon}
 
-    PKG_CONFIG_PATH=${pkgs.gobject-introspection}
+      # Add LuaJIT include directory, 
+      export LUA_INCDIR=${pkgs.luajit}/include
 
-    luarocks install --server=https://luarocks.org/dev tstation --lua-version=5.1 --local
+      PKG_CONFIG_PATH=${pkgs.gobject-introspection}
 
-    luarocks --lua-version=5.1 make --local \
-      CAIRO_DIR="$CAIRO_DIR" EV_DIR="$EV_DIR" \
-      LUAJIT_5_1_DIR="$LUAJIT_5_1_DIR" \
-      X11_DIR="$X11_DIR" XCB_DIR="$XCB_DIR" \
-      XCB_CURSOR_DIR="$XCB_CURSOR_DIR" \
-      XCB_ERRORS_DIR="$XCB_ERRORS_DIR" \
-      XCB_KEYSYMS_DIR="$XCB_KEYSYMS_DIR" \
-      XKBCOMMON_DIR="$XKBCOMMON_DIR" \
-      XKBCOMMON_X11_DIR="$XKBCOMMON_X11_DIR" \
-      LUA_INCDIR="$LUA_INCDIR" \
-      CFLAGS="-I$XCB_HEADER_DIR/include"
+      luarocks install --server=https://luarocks.org/dev tstation --lua-version=5.1 --local
 
-    export LUA_PATH="/home/nikolasd/.luarocks/share/lua/5.1/?.lua;;"
-    export LUA_CPATH="/home/nikolasd/.luarocks/lib/lua/5.1/?.so;;"
+      luarocks --lua-version=5.1 make --local \
+        CAIRO_DIR="$CAIRO_DIR" EV_DIR="$EV_DIR" \
+        LUAJIT_5_1_DIR="$LUAJIT_5_1_DIR" \
+        X11_DIR="$X11_DIR" XCB_DIR="$XCB_DIR" \
+        XCB_CURSOR_DIR="$XCB_CURSOR_DIR" \
+        XCB_ERRORS_DIR="$XCB_ERRORS_DIR" \
+        XCB_KEYSYMS_DIR="$XCB_KEYSYMS_DIR" \
+        XKBCOMMON_DIR="$XKBCOMMON_DIR" \
+        XKBCOMMON_X11_DIR="$XKBCOMMON_X11_DIR" \
+        LUA_INCDIR="$LUA_INCDIR" \
+        CFLAGS="-I$XCB_HEADER_DIR/include"
+    else
+      echo -e "\033[33mLibrary not recompiled, to recompile run 'nix-shell --arg recompile true'\033[0m"
+    fi
+        
+    # As long as luajit stays on 5.1 we're safe (pretty likely)
+    export LUA_PATH="$HOME/.luarocks/share/lua/5.1/?.lua;;" 
+    export LUA_CPATH="$HOME/.luarocks/lib/lua/5.1/?.so;;"
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,66 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.lua5_1
+    pkgs.luarocks
+    pkgs.luajit
+    pkgs.cairo
+    pkgs.pango # needed for lgi
+    pkgs.libev
+    pkgs.pkg-config
+    pkgs.xorg.libX11
+    pkgs.xorg.libxcb
+    pkgs.xorg.xcbutil
+    pkgs.xcb-util-cursor
+    pkgs.xorg.xcbutilerrors
+    pkgs.xorg.xcbutilkeysyms
+    pkgs.libxkbcommon
+
+    pkgs.luajitPackages.lgi
+    pkgs.lua51Packages.lgi
+    pkgs.gobject-introspection
+  ];
+
+  shellHook = ''
+    # Set environment variables for the libraries
+    export CAIRO_DIR=${pkgs.cairo}
+    export EV_DIR=${pkgs.libev}
+    export LUAJIT_5_1_DIR=${pkgs.luajit}
+    export X11_DIR=${pkgs.xorg.libX11}
+    export XCB_DIR=${pkgs.xorg.libxcb}
+
+    # Some jank to extract the header directory to pass to the includes
+    export XCB_UTIL_DIR=${pkgs.xorg.xcbutil}
+    export XCB_UTIL_DRV_DIR=$(nix-store --query --deriver $XCB_UTIL_DIR)
+    export XCB_HEADER_DIR=$(nix-store --query --outputs $XCB_UTIL_DRV_DIR | grep "dev")
+
+    export XCB_CURSOR_DIR=${pkgs.xcb-util-cursor}
+    export XCB_ERRORS_DIR=${pkgs.xorg.xcbutilerrors}
+    export XCB_KEYSYMS_DIR=${pkgs.xorg.xcbutilkeysyms}
+    export XKBCOMMON_DIR=${pkgs.libxkbcommon}
+    export XKBCOMMON_X11_DIR=${pkgs.libxkbcommon}
+
+    # Add LuaJIT include directory
+    export LUA_INCDIR=${pkgs.luajit}/include/luajit-2.1
+
+    PKG_CONFIG_PATH=${pkgs.gobject-introspection}
+
+    luarocks install --server=https://luarocks.org/dev tstation --lua-version=5.1 --local
+
+    luarocks --lua-version=5.1 make --local \
+      CAIRO_DIR="$CAIRO_DIR" EV_DIR="$EV_DIR" \
+      LUAJIT_5_1_DIR="$LUAJIT_5_1_DIR" \
+      X11_DIR="$X11_DIR" XCB_DIR="$XCB_DIR" \
+      XCB_CURSOR_DIR="$XCB_CURSOR_DIR" \
+      XCB_ERRORS_DIR="$XCB_ERRORS_DIR" \
+      XCB_KEYSYMS_DIR="$XCB_KEYSYMS_DIR" \
+      XKBCOMMON_DIR="$XKBCOMMON_DIR" \
+      XKBCOMMON_X11_DIR="$XKBCOMMON_X11_DIR" \
+      LUA_INCDIR="$LUA_INCDIR" \
+      CFLAGS="-I$XCB_HEADER_DIR/include"
+
+    export LUA_PATH="/home/nikolasd/.luarocks/share/lua/5.1/?.lua;;"
+    export LUA_CPATH="/home/nikolasd/.luarocks/lib/lua/5.1/?.so;;"
+  '';
+}


### PR DESCRIPTION
This is a little build / shell script I whipped up over the last few days. It was a huge pain to manually pass all the environment variables to luarocks, I don't know if there was a better way, but it seemed to not take exported variables. Anyway it's fully functional and well tested. 

I opted for a shell environment rather than a default.nix because I had luarocks install locally. I couldn't get luarocks to work globally even with sudo so it needs to set a few lua path variables in order to have luajit find the libraries correctly. Nixos doesn't seem to support / have documentation on global luarocks. This is really a pain on nix without it because I had to find and setup every one of the dependencies manually so it's very nice to have if you're on nixos.